### PR TITLE
feat: add initial API spec and types

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   title: ReFi.Trading API
   version: 0.1.0
@@ -65,6 +65,7 @@ components:
       type: object
       required:
         - order_preview_id
+        - action
         - proof
         - policy
         - trace_id
@@ -74,6 +75,10 @@ components:
           format: uuid
         action:
           type: object
+          required:
+            - symbol
+            - side
+            - qty
           properties:
             symbol:
               type: string

--- a/src/lib/supervisor.ts
+++ b/src/lib/supervisor.ts
@@ -1,3 +1,6 @@
+/**
+ * Determine whether an order reduces the absolute position size.
+ */
 export function isReduction(currentQty: number, side: 'buy' | 'sell', qty: number): boolean {
   const nextQty = currentQty + (side === 'buy' ? +qty : -qty)
   return Math.abs(nextQty) < Math.abs(currentQty)
@@ -9,6 +12,9 @@ export interface SupervisorDecisionCtx {
   currentQty: number
 }
 
+/**
+ * Combine upstream checks and safe-mode status to decide on an order.
+ */
 export function supervisorDecision(ctx: SupervisorDecisionCtx): 'APPROVE' | 'REJECT' | 'APPROVE_REDUCTION_ONLY' {
   const { aceOk, varOk, degraded } = ctx.checks
   const { order, currentQty } = ctx

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,7 +1,7 @@
 export interface OrderPreviewAction {
-  symbol?: string
-  side?: 'buy' | 'sell'
-  qty?: number
+  symbol: string
+  side: 'buy' | 'sell'
+  qty: number
 }
 
 export interface OrderPreviewProof {
@@ -19,7 +19,7 @@ export interface OrderPreviewPolicy {
 
 export interface OrderPreviewResult {
   order_preview_id: string
-  action?: OrderPreviewAction
+  action: OrderPreviewAction
   proof: OrderPreviewProof
   policy: OrderPreviewPolicy
   trace_id: string


### PR DESCRIPTION
## Summary
- add initial OpenAPI spec with core endpoints
- define OrderPreviewResult TypeScript types

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple pre-existing lint errors)*
- `npx eslint src/types/api.ts && echo 'eslint-ok'`


------
https://chatgpt.com/codex/tasks/task_e_68a2a92b583c8326811979582e44dbcb