### PR TITLE
feat: scaffold anchoring worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-refi-trading-gui7
+# ReFi.Trading GUI
+
+Prototype implementation exploring ReFi.Trading's dual-proof gate for
+safe, non-custodial algorithmic trading.
+
+## Features
+
+- **OpenAPI 3.1 spec** for core endpoints in `openapi/openapi.yaml`.
+- **TypeScript types** for the `OrderPreviewResult` contract in
+  `src/types/api.ts`.
+- **ACE policy** and **zk-VaR proof** clients with fail-closed
+  semantics in `src/lib/ace.ts` and `src/lib/var.ts`.
+- **Supervisor decision logic** enforcing reductions-only safe-mode
+  when downstream services degrade in `src/lib/supervisor.ts`.
+- **zkSync anchoring client** for committing previews and fills to an
+  immutable audit trail in `src/lib/anchor.ts`.
+- **Anchoring worker scaffold** with start/stop hooks in
+  `src/workers/anchor.ts`.
+
+## Development
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run lint on the core modules:
+
+```bash
+npx eslint src/lib/ace.ts src/lib/var.ts src/lib/supervisor.ts src/lib/anchor.ts src/workers/anchor.ts src/types/api.ts
+```
+
+Check for security vulnerabilities:
+
+```bash
+npm run audit
+```
+
+Run the unit test suite:
+
+```bash
+npm test
+```
+
+### On-Chain Anchoring
+
+Configure environment variables for the anchor worker:
+
+```bash
+export ANCHOR_RPC_URL="https://zksync-era.blockchain" # RPC endpoint
+export ANCHOR_CONTRACT_ADDRESS="0xYourContract"     # IAuditAnchor address
+export ANCHOR_PRIVATE_KEY="0xYourKey"                # wallet key
+export ANCHOR_TIMEOUT_MS="10000"                     # optional timeout
+```
+
+The `AnchorClient` in `src/lib/anchor.ts` uses these values to submit
+`anchorPreview` and `anchorFill` transactions to zkSync Era.
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ safe, non-custodial algorithmic trading.
   immutable audit trail in `src/lib/anchor.ts`.
 - **Anchoring worker scaffold** with start/stop hooks in
   `src/workers/anchor.ts`.
+- **NestJS API gateway skeleton** with stub endpoints in
+  `server/src/`.
 
 ## Development
 
@@ -41,6 +43,12 @@ Run the unit test suite:
 
 ```bash
 npm test
+```
+
+Run the API gateway (stubbed responses):
+
+```bash
+tsc server/src/main.ts --outDir dist-server && node dist-server/main.js
 ```
 
 ### On-Chain Anchoring

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,121 @@
+openapi: 3.1.0
+info:
+  title: ReFi.Trading API
+  version: 0.1.0
+paths:
+  /snaptrade/portal:
+    post:
+      summary: Create SnapTrade Connection Portal URL
+      responses:
+        '200':
+          description: Portal URL created
+  /webhooks/snaptrade:
+    post:
+      summary: SnapTrade webhook receiver (trades/holdings/connection)
+      responses:
+        '200':
+          description: Webhook received
+  /orders/preview:
+    post:
+      summary: Dual-proof preview (no execution)
+      responses:
+        '200':
+          description: Preview bundle
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderPreviewResult'
+        '409':
+          description: Safe-mode / policy unavailable
+  /orders:
+    post:
+      summary: Execute order from preview (ERC-4337 session key)
+      responses:
+        '202':
+          description: Accepted
+        '409':
+          description: Mismatch or expired preview
+  /proofs/{proof_id}:
+    get:
+      summary: Get zk-VaR proof metadata
+      parameters:
+        - name: proof_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Proof metadata
+  /verdicts/{verdict_id}:
+    get:
+      summary: Get ACE policy verdict
+      parameters:
+        - name: verdict_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ACE policy verdict
+components:
+  schemas:
+    OrderPreviewResult:
+      type: object
+      required:
+        - order_preview_id
+        - action
+        - proof
+        - policy
+        - trace_id
+      properties:
+        order_preview_id:
+          type: string
+          format: uuid
+        action:
+          type: object
+          required:
+            - symbol
+            - side
+            - qty
+          properties:
+            symbol:
+              type: string
+            side:
+              type: string
+              enum: [buy, sell]
+            qty:
+              type: number
+        proof:
+          type: object
+          required:
+            - proof_id
+            - hash
+            - ok
+            - var_value
+          properties:
+            proof_id:
+              type: string
+            hash:
+              type: string
+            ok:
+              type: boolean
+            var_value:
+              type: number
+        policy:
+          type: object
+          required:
+            - verdict_id
+            - allow
+          properties:
+            verdict_id:
+              type: string
+            allow:
+              type: boolean
+            reasons:
+              type: array
+              items:
+                type: string
+        trace_id:
+          type: string

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "tsc src/lib/supervisor.ts src/lib/anchor.ts src/workers/anchor.ts --outDir dist --noEmit false --module ES2020 --moduleResolution Bundler --target ES2020 --skipLibCheck true && node --test tests/supervisor.test.js tests/anchor-worker.test.js && rm -rf dist",
+    "audit": "npm audit"
   },
   "dependencies": {
     "@nestjs/common": "^10.3.0",

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { OrdersController } from './orders.controller.js';
+import { ProofsController } from './proofs.controller.js';
+import { VerdictsController } from './verdicts.controller.js';
+import { SnapTradeController } from './snaptrade.controller.js';
+
+@Module({
+  controllers: [OrdersController, ProofsController, VerdictsController, SnapTradeController],
+})
+export class AppModule {}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,0 +1,10 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module.js';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+
+bootstrap();

--- a/server/src/orders.controller.ts
+++ b/server/src/orders.controller.ts
@@ -1,0 +1,25 @@
+import { Body, Controller, HttpCode, Post } from '@nestjs/common';
+import type { OrderPreviewResult } from '../../src/types/api';
+
+@Controller('orders')
+export class OrdersController {
+  @Post('preview')
+  @HttpCode(200)
+  preview(@Body() body: unknown): OrderPreviewResult {
+    void body;
+    return {
+      order_preview_id: '00000000-0000-0000-0000-000000000000',
+      action: { symbol: 'AAPL', side: 'buy', qty: 1 },
+      proof: { proof_id: 'proof', hash: '0x0', ok: true, var_value: 0 },
+      policy: { verdict_id: 'verdict', allow: true, reasons: [] },
+      trace_id: 'trace',
+    };
+  }
+
+  @Post()
+  @HttpCode(202)
+  place(@Body() body: unknown) {
+    void body;
+    return { status: 'ACCEPTED' };
+  }
+}

--- a/server/src/proofs.controller.ts
+++ b/server/src/proofs.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get, Param } from '@nestjs/common';
+
+@Controller('proofs')
+export class ProofsController {
+  @Get(':id')
+  getProof(@Param('id') id: string) {
+    return { proof_id: id, hash: '0x0', ok: true, var_value: 0 };
+  }
+}

--- a/server/src/snaptrade.controller.ts
+++ b/server/src/snaptrade.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, HttpCode, Post } from '@nestjs/common';
+
+@Controller()
+export class SnapTradeController {
+  @Post('snaptrade/portal')
+  createPortal() {
+    return { url: 'https://example.com/portal' };
+  }
+
+  @Post('webhooks/snaptrade')
+  @HttpCode(200)
+  handleWebhook() {
+    return { ok: true };
+  }
+}

--- a/server/src/verdicts.controller.ts
+++ b/server/src/verdicts.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get, Param } from '@nestjs/common';
+
+@Controller('verdicts')
+export class VerdictsController {
+  @Get(':id')
+  getVerdict(@Param('id') id: string) {
+    return { verdict_id: id, allow: true, reasons: [] };
+  }
+}

--- a/src/lib/ace.ts
+++ b/src/lib/ace.ts
@@ -1,0 +1,44 @@
+import type { OrderPreviewAction, OrderPreviewPolicy } from '../types/api'
+
+export interface AceClientConfig {
+  baseUrl: string
+  timeoutMs?: number
+}
+
+/**
+ * Minimal ACE client that fails closed on errors or timeouts.
+ */
+export class AceClient {
+  private baseUrl: string
+  private timeoutMs: number
+
+  constructor(cfg: AceClientConfig) {
+    this.baseUrl = cfg.baseUrl
+    this.timeoutMs = cfg.timeoutMs ?? 5000
+  }
+
+  async evaluate(
+    action: OrderPreviewAction,
+  ): Promise<{ policy: OrderPreviewPolicy | null; degraded: boolean }> {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs)
+    try {
+      const res = await fetch(`${this.baseUrl}/verdicts`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(action),
+        signal: controller.signal,
+      })
+      if (!res.ok) {
+        return { policy: null, degraded: true }
+      }
+      const policy = (await res.json()) as OrderPreviewPolicy
+      return { policy, degraded: false }
+    } catch {
+      return { policy: null, degraded: true }
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+}
+

--- a/src/lib/anchor.ts
+++ b/src/lib/anchor.ts
@@ -1,0 +1,76 @@
+import { Contract, JsonRpcProvider, Wallet, TransactionReceipt } from 'ethers'
+
+const anchorAbi = [
+  'function anchorPreview(bytes32 previewId, bytes32 proofCid, bytes32 verdictCid, bytes32 traceId)',
+  'function anchorFill(bytes32 orderId, bytes32 fillCid, int256 deltaNotional, int256 slippageBps, bytes32 traceId)'
+] as const
+
+export interface AnchorClientConfig {
+  rpcUrl: string
+  contractAddress: string
+  privateKey: string
+  timeoutMs?: number
+}
+
+/**
+ * Minimal client for anchoring previews and fills on zkSync Era.
+ */
+export class AnchorClient {
+  private contract: Contract
+  private timeoutMs: number
+
+  constructor(cfg: AnchorClientConfig) {
+    const provider = new JsonRpcProvider(cfg.rpcUrl)
+    const wallet = new Wallet(cfg.privateKey, provider)
+    this.contract = new Contract(cfg.contractAddress, anchorAbi, wallet)
+    this.timeoutMs = cfg.timeoutMs ?? 10000
+  }
+
+  private withTimeout<T>(p: Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('timeout')), this.timeoutMs)
+      p.then((v) => {
+        clearTimeout(timer)
+        resolve(v)
+      }).catch((err) => {
+        clearTimeout(timer)
+        reject(err)
+      })
+    })
+  }
+
+  async anchorPreview(
+    previewId: string,
+    proofCid: string,
+    verdictCid: string,
+    traceId: string,
+  ): Promise<{ txHash: string | null }> {
+    try {
+      const tx = await this.withTimeout(
+        this.contract.anchorPreview(previewId, proofCid, verdictCid, traceId),
+      )
+      const receipt = (await this.withTimeout(tx.wait())) as TransactionReceipt
+      return { txHash: receipt.hash }
+    } catch {
+      return { txHash: null }
+    }
+  }
+
+  async anchorFill(
+    orderId: string,
+    fillCid: string,
+    deltaNotional: bigint,
+    slippageBps: bigint,
+    traceId: string,
+  ): Promise<{ txHash: string | null }> {
+    try {
+      const tx = await this.withTimeout(
+        this.contract.anchorFill(orderId, fillCid, deltaNotional, slippageBps, traceId),
+      )
+      const receipt = (await this.withTimeout(tx.wait())) as TransactionReceipt
+      return { txHash: receipt.hash }
+    } catch {
+      return { txHash: null }
+    }
+  }
+}

--- a/src/lib/supervisor.ts
+++ b/src/lib/supervisor.ts
@@ -1,0 +1,26 @@
+/**
+ * Determine whether an order reduces the absolute position size.
+ */
+export function isReduction(currentQty: number, side: 'buy' | 'sell', qty: number): boolean {
+  const nextQty = currentQty + (side === 'buy' ? +qty : -qty)
+  return Math.abs(nextQty) < Math.abs(currentQty)
+}
+
+export interface SupervisorDecisionCtx {
+  checks: { aceOk: boolean; varOk: boolean; degraded: boolean }
+  order: { side: 'buy' | 'sell'; qty: number }
+  currentQty: number
+}
+
+/**
+ * Combine upstream checks and safe-mode status to decide on an order.
+ */
+export function supervisorDecision(ctx: SupervisorDecisionCtx): 'APPROVE' | 'REJECT' | 'APPROVE_REDUCTION_ONLY' {
+  const { aceOk, varOk, degraded } = ctx.checks
+  const { order, currentQty } = ctx
+  if (!degraded) {
+    return aceOk && varOk ? 'APPROVE' : 'REJECT'
+  }
+  // In degraded mode, only allow reductions
+  return isReduction(currentQty, order.side, order.qty) ? 'APPROVE_REDUCTION_ONLY' : 'REJECT'
+}

--- a/src/lib/var.ts
+++ b/src/lib/var.ts
@@ -1,0 +1,44 @@
+import type { OrderPreviewAction, OrderPreviewProof } from '../types/api'
+
+export interface VarProofClientConfig {
+  baseUrl: string
+  timeoutMs?: number
+}
+
+/**
+ * Client for the zk-VaR proof service with fail-closed semantics.
+ */
+export class VarProofClient {
+  private baseUrl: string
+  private timeoutMs: number
+
+  constructor(cfg: VarProofClientConfig) {
+    this.baseUrl = cfg.baseUrl
+    this.timeoutMs = cfg.timeoutMs ?? 8000
+  }
+
+  async prove(
+    action: OrderPreviewAction,
+  ): Promise<{ proof: OrderPreviewProof | null; degraded: boolean }> {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs)
+    try {
+      const res = await fetch(`${this.baseUrl}/prove`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(action),
+        signal: controller.signal,
+      })
+      if (!res.ok) {
+        return { proof: null, degraded: true }
+      }
+      const proof = (await res.json()) as OrderPreviewProof
+      return { proof, degraded: false }
+    } catch {
+      return { proof: null, degraded: true }
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+}
+

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,26 @@
+export interface OrderPreviewAction {
+  symbol: string
+  side: 'buy' | 'sell'
+  qty: number
+}
+
+export interface OrderPreviewProof {
+  proof_id: string
+  hash: string
+  ok: boolean
+  var_value: number
+}
+
+export interface OrderPreviewPolicy {
+  verdict_id: string
+  allow: boolean
+  reasons?: string[]
+}
+
+export interface OrderPreviewResult {
+  order_preview_id: string
+  action: OrderPreviewAction
+  proof: OrderPreviewProof
+  policy: OrderPreviewPolicy
+  trace_id: string
+}

--- a/src/workers/anchor.ts
+++ b/src/workers/anchor.ts
@@ -1,0 +1,67 @@
+import { AnchorClient } from '../lib/anchor.js'
+
+export interface AnchorWorkerOptions {
+  rpcUrl: string
+  contractAddress: string
+  privateKey: string
+  timeoutMs?: number
+}
+
+/**
+ * AnchorWorker wraps AnchorClient with start/stop hooks.
+ * Actual event consumption will be wired later once messaging exists.
+ */
+export class AnchorWorker {
+  private client: AnchorClient
+  private running = false
+
+  constructor(opts: AnchorWorkerOptions) {
+    this.client = new AnchorClient(opts)
+  }
+
+  start() {
+    this.running = true
+  }
+
+  stop() {
+    this.running = false
+  }
+
+  async anchorPreview(
+    previewId: string,
+    proofCid: string,
+    verdictCid: string,
+    traceId: string,
+  ) {
+    return this.running
+      ? this.client.anchorPreview(previewId, proofCid, verdictCid, traceId)
+      : { txHash: null }
+  }
+
+  async anchorFill(
+    orderId: string,
+    fillCid: string,
+    deltaNotional: bigint,
+    slippageBps: bigint,
+    traceId: string,
+  ) {
+    return this.running
+      ? this.client.anchorFill(orderId, fillCid, deltaNotional, slippageBps, traceId)
+      : { txHash: null }
+  }
+}
+
+export function createAnchorWorkerFromEnv(): AnchorWorker {
+  const rpcUrl = process.env.ANCHOR_RPC_URL
+  const contractAddress = process.env.ANCHOR_CONTRACT_ADDRESS
+  const privateKey = process.env.ANCHOR_PRIVATE_KEY
+  const timeoutMs = process.env.ANCHOR_TIMEOUT_MS
+    ? parseInt(process.env.ANCHOR_TIMEOUT_MS, 10)
+    : undefined
+
+  if (!rpcUrl || !contractAddress || !privateKey) {
+    throw new Error('missing anchoring env vars')
+  }
+
+  return new AnchorWorker({ rpcUrl, contractAddress, privateKey, timeoutMs })
+}

--- a/tests/anchor-worker.test.js
+++ b/tests/anchor-worker.test.js
@@ -1,0 +1,30 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createAnchorWorkerFromEnv } from '../dist/workers/anchor.js'
+
+function withEnv(env, fn) {
+  const old = { ...process.env }
+  Object.assign(process.env, env)
+  try {
+    return fn()
+  } finally {
+    process.env = old
+  }
+}
+
+test('creates worker from env vars', () => {
+  withEnv(
+    {
+      ANCHOR_RPC_URL: 'http://localhost:8545',
+      ANCHOR_CONTRACT_ADDRESS: '0x0000000000000000000000000000000000000000',
+      ANCHOR_PRIVATE_KEY:
+        '0x1111111111111111111111111111111111111111111111111111111111111111',
+    },
+    () => {
+      const worker = createAnchorWorkerFromEnv()
+      worker.start()
+      worker.stop()
+      assert.ok(worker)
+    },
+  )
+})

--- a/tests/supervisor.test.js
+++ b/tests/supervisor.test.js
@@ -1,0 +1,21 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { supervisorDecision } from '../dist/lib/supervisor.js'
+
+test('approves when checks pass', () => {
+  const decision = supervisorDecision({
+    checks: { aceOk: true, varOk: true, degraded: false },
+    order: { side: 'buy', qty: 1 },
+    currentQty: 0,
+  })
+  assert.equal(decision, 'APPROVE')
+})
+
+test('allows only reductions when degraded', () => {
+  const decision = supervisorDecision({
+    checks: { aceOk: false, varOk: false, degraded: true },
+    order: { side: 'sell', qty: 5 },
+    currentQty: 10,
+  })
+  assert.equal(decision, 'APPROVE_REDUCTION_ONLY')
+})


### PR DESCRIPTION
## Summary
- add worker wrapper around AnchorClient with start/stop hooks and env-based config
- update README with anchoring worker setup and lint/test commands
- expand test script and add unit test for anchor worker

## Testing
- `npx eslint src/lib/anchor.ts src/workers/anchor.ts src/lib/ace.ts src/lib/var.ts src/lib/supervisor.ts src/types/api.ts`
- `npm test`
- `npm run audit` *(fails: 403 Forbidden contacting npm advisories API)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a92b583c8326811979582e44dbcb