### PR TITLE
feat: implement dual-proof preview orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,72 @@
-refi-trading-gui7
+# ReFi.Trading GUI
+
+Prototype implementation exploring ReFi.Trading's dual-proof gate for
+safe, non-custodial algorithmic trading.
+
+## Features
+
+- **OpenAPI 3.1 spec** for core endpoints in `openapi/openapi.yaml`.
+- **TypeScript types** for the `OrderPreviewResult` contract in
+  `src/types/api.ts`.
+- **ACE policy** and **zk-VaR proof** clients with fail-closed
+  semantics in `src/lib/ace.ts` and `src/lib/var.ts`.
+- **Supervisor decision logic** enforcing reductions-only safe-mode
+  when downstream services degrade in `src/lib/supervisor.ts`.
+- **zkSync anchoring client** for committing previews and fills to an
+  immutable audit trail in `src/lib/anchor.ts`.
+- **Anchoring worker scaffold** with start/stop hooks in
+  `src/workers/anchor.ts`.
+- **NestJS API gateway** with a `/orders/preview` endpoint that
+  concurrently consults the ACE and zk-VaR services and applies
+  supervisor safe-mode logic. Other endpoints remain stubbed in
+  `server/src/`.
+
+## Development
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run lint on the core modules:
+
+```bash
+npx eslint src/lib/ace.ts src/lib/var.ts src/lib/supervisor.ts src/lib/anchor.ts src/workers/anchor.ts src/types/api.ts
+```
+
+Check for security vulnerabilities:
+
+```bash
+npm run audit
+```
+
+Run the unit test suite:
+
+```bash
+npm test
+```
+
+Run the API gateway (stubbed responses):
+
+```bash
+tsc server/src/main.ts --outDir dist-server && node dist-server/main.js
+```
+
+### On-Chain Anchoring
+
+Configure environment variables for the anchor worker:
+
+```bash
+export ANCHOR_RPC_URL="https://zksync-era.blockchain" # RPC endpoint
+export ANCHOR_CONTRACT_ADDRESS="0xYourContract"     # IAuditAnchor address
+export ANCHOR_PRIVATE_KEY="0xYourKey"                # wallet key
+export ANCHOR_TIMEOUT_MS="10000"                     # optional timeout
+```
+
+The `AnchorClient` in `src/lib/anchor.ts` uses these values to submit
+`anchorPreview` and `anchorFill` transactions to zkSync Era.
+
+## License
+
+MIT

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,0 +1,147 @@
+openapi: 3.1.0
+info:
+  title: ReFi.Trading API
+  version: 0.1.0
+paths:
+  /snaptrade/portal:
+    post:
+      summary: Create SnapTrade Connection Portal URL
+      responses:
+        '200':
+          description: Portal URL created
+  /webhooks/snaptrade:
+    post:
+      summary: SnapTrade webhook receiver (trades/holdings/connection)
+      responses:
+        '200':
+          description: Webhook received
+  /orders/preview:
+    post:
+      summary: Dual-proof preview (no execution)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [action, currentQty]
+              properties:
+                action:
+                  $ref: '#/components/schemas/OrderPreviewAction'
+                currentQty:
+                  type: number
+      responses:
+        '200':
+          description: Preview bundle
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderPreviewResult'
+        '409':
+          description: Safe-mode / policy unavailable
+  /orders:
+    post:
+      summary: Execute order from preview (ERC-4337 session key)
+      responses:
+        '202':
+          description: Accepted
+        '409':
+          description: Mismatch or expired preview
+  /proofs/{proof_id}:
+    get:
+      summary: Get zk-VaR proof metadata
+      parameters:
+        - name: proof_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Proof metadata
+  /verdicts/{verdict_id}:
+    get:
+      summary: Get ACE policy verdict
+      parameters:
+        - name: verdict_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ACE policy verdict
+components:
+  schemas:
+    OrderPreviewResult:
+      type: object
+      required:
+        - order_preview_id
+        - action
+        - proof
+        - policy
+        - trace_id
+      properties:
+        order_preview_id:
+          type: string
+          format: uuid
+        action:
+          type: object
+          required:
+            - symbol
+            - side
+            - qty
+          properties:
+            symbol:
+              type: string
+            side:
+              type: string
+              enum: [buy, sell]
+            qty:
+              type: number
+        proof:
+          type: object
+          required:
+            - proof_id
+            - hash
+            - ok
+            - var_value
+          properties:
+            proof_id:
+              type: string
+            hash:
+              type: string
+            ok:
+              type: boolean
+            var_value:
+              type: number
+        policy:
+          type: object
+          required:
+            - verdict_id
+            - allow
+          properties:
+            verdict_id:
+              type: string
+            allow:
+              type: boolean
+            reasons:
+              type: array
+              items:
+                type: string
+        trace_id:
+          type: string
+    OrderPreviewAction:
+      type: object
+      required:
+        - symbol
+        - side
+        - qty
+      properties:
+        symbol:
+          type: string
+        side:
+          type: string
+          enum: [buy, sell]
+        qty:
+          type: number

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "tsc src/lib/ace.ts src/lib/var.ts src/lib/supervisor.ts src/lib/anchor.ts src/workers/anchor.ts server/src/orders.service.ts --outDir dist --noEmit false --module ES2020 --moduleResolution Bundler --target ES2020 --skipLibCheck true && node --test tests/supervisor.test.js tests/anchor-worker.test.js tests/orders-preview.test.js && rm -rf dist",
+    "audit": "npm audit"
   },
   "dependencies": {
     "@nestjs/common": "^10.3.0",

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { OrdersController } from './orders.controller.js';
+import { ProofsController } from './proofs.controller.js';
+import { VerdictsController } from './verdicts.controller.js';
+import { SnapTradeController } from './snaptrade.controller.js';
+import { OrdersService } from './orders.service.js';
+import { PrismaService } from './prisma.service.js';
+
+@Module({
+  controllers: [OrdersController, ProofsController, VerdictsController, SnapTradeController],
+  providers: [OrdersService, PrismaService],
+})
+export class AppModule {}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -1,0 +1,10 @@
+import 'reflect-metadata';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module.js';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3000);
+}
+
+bootstrap();

--- a/server/src/orders.controller.ts
+++ b/server/src/orders.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, HttpCode, Post } from '@nestjs/common';
+import type { OrderPreviewAction, OrderPreviewResult } from '../../src/types/api';
+import { OrdersService } from './orders.service.js';
+
+@Controller('orders')
+export class OrdersController {
+  constructor(private readonly orders: OrdersService) {}
+
+  @Post('preview')
+  @HttpCode(200)
+  async preview(
+    @Body()
+    body: { action: OrderPreviewAction; currentQty: number },
+  ): Promise<OrderPreviewResult> {
+    return this.orders.preview(body.action, body.currentQty);
+  }
+
+  @Post()
+  @HttpCode(202)
+  place(@Body() body: unknown) {
+    void body;
+    return { status: 'ACCEPTED' };
+  }
+}

--- a/server/src/orders.service.ts
+++ b/server/src/orders.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, HttpException } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import type { OrderPreviewAction, OrderPreviewResult } from '../../src/types/api';
+import { AceClient } from '../../src/lib/ace.js';
+import { VarProofClient } from '../../src/lib/var.js';
+import { supervisorDecision } from '../../src/lib/supervisor.js';
+
+interface ClientDeps {
+  ace: AceClient;
+  var: VarProofClient;
+}
+
+@Injectable()
+export class OrdersService {
+  private ace: AceClient;
+  private var: VarProofClient;
+
+  constructor(deps?: ClientDeps) {
+    this.ace = deps?.ace ?? new AceClient({ baseUrl: process.env.ACE_URL ?? '' });
+    this.var = deps?.var ?? new VarProofClient({ baseUrl: process.env.VAR_URL ?? '' });
+  }
+
+  async preview(action: OrderPreviewAction, currentQty: number): Promise<OrderPreviewResult> {
+    const [aceRes, varRes] = await Promise.all([
+      this.ace.evaluate(action),
+      this.var.prove(action),
+    ]);
+
+    const checks = {
+      aceOk: !!aceRes.policy?.allow,
+      varOk: !!varRes.proof?.ok,
+      degraded: aceRes.degraded || varRes.degraded,
+    };
+
+    const decision = supervisorDecision({ checks, order: action, currentQty });
+
+    if (checks.degraded || decision === 'REJECT') {
+      throw new HttpException('SAFE_MODE', 409);
+    }
+
+    return {
+      order_preview_id: randomUUID(),
+      action,
+      proof: varRes.proof!,
+      policy: aceRes.policy!,
+      trace_id: randomUUID(),
+    };
+  }
+}
+

--- a/server/src/prisma.service.ts
+++ b/server/src/prisma.service.ts
@@ -1,0 +1,17 @@
+import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService
+  extends PrismaClient
+  implements OnModuleInit, OnModuleDestroy
+{
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async onModuleDestroy() {
+    await this.$disconnect();
+  }
+}
+

--- a/server/src/proofs.controller.ts
+++ b/server/src/proofs.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get, Param } from '@nestjs/common';
+
+@Controller('proofs')
+export class ProofsController {
+  @Get(':id')
+  getProof(@Param('id') id: string) {
+    return { proof_id: id, hash: '0x0', ok: true, var_value: 0 };
+  }
+}

--- a/server/src/snaptrade.controller.ts
+++ b/server/src/snaptrade.controller.ts
@@ -1,0 +1,15 @@
+import { Controller, HttpCode, Post } from '@nestjs/common';
+
+@Controller()
+export class SnapTradeController {
+  @Post('snaptrade/portal')
+  createPortal() {
+    return { url: 'https://example.com/portal' };
+  }
+
+  @Post('webhooks/snaptrade')
+  @HttpCode(200)
+  handleWebhook() {
+    return { ok: true };
+  }
+}

--- a/server/src/verdicts.controller.ts
+++ b/server/src/verdicts.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get, Param } from '@nestjs/common';
+
+@Controller('verdicts')
+export class VerdictsController {
+  @Get(':id')
+  getVerdict(@Param('id') id: string) {
+    return { verdict_id: id, allow: true, reasons: [] };
+  }
+}

--- a/src/lib/ace.ts
+++ b/src/lib/ace.ts
@@ -1,0 +1,44 @@
+import type { OrderPreviewAction, OrderPreviewPolicy } from '../types/api'
+
+export interface AceClientConfig {
+  baseUrl: string
+  timeoutMs?: number
+}
+
+/**
+ * Minimal ACE client that fails closed on errors or timeouts.
+ */
+export class AceClient {
+  private baseUrl: string
+  private timeoutMs: number
+
+  constructor(cfg: AceClientConfig) {
+    this.baseUrl = cfg.baseUrl
+    this.timeoutMs = cfg.timeoutMs ?? 5000
+  }
+
+  async evaluate(
+    action: OrderPreviewAction,
+  ): Promise<{ policy: OrderPreviewPolicy | null; degraded: boolean }> {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs)
+    try {
+      const res = await fetch(`${this.baseUrl}/verdicts`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(action),
+        signal: controller.signal,
+      })
+      if (!res.ok) {
+        return { policy: null, degraded: true }
+      }
+      const policy = (await res.json()) as OrderPreviewPolicy
+      return { policy, degraded: false }
+    } catch {
+      return { policy: null, degraded: true }
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+}
+

--- a/src/lib/anchor.ts
+++ b/src/lib/anchor.ts
@@ -1,0 +1,76 @@
+import { Contract, JsonRpcProvider, Wallet, TransactionReceipt } from 'ethers'
+
+const anchorAbi = [
+  'function anchorPreview(bytes32 previewId, bytes32 proofCid, bytes32 verdictCid, bytes32 traceId)',
+  'function anchorFill(bytes32 orderId, bytes32 fillCid, int256 deltaNotional, int256 slippageBps, bytes32 traceId)'
+] as const
+
+export interface AnchorClientConfig {
+  rpcUrl: string
+  contractAddress: string
+  privateKey: string
+  timeoutMs?: number
+}
+
+/**
+ * Minimal client for anchoring previews and fills on zkSync Era.
+ */
+export class AnchorClient {
+  private contract: Contract
+  private timeoutMs: number
+
+  constructor(cfg: AnchorClientConfig) {
+    const provider = new JsonRpcProvider(cfg.rpcUrl)
+    const wallet = new Wallet(cfg.privateKey, provider)
+    this.contract = new Contract(cfg.contractAddress, anchorAbi, wallet)
+    this.timeoutMs = cfg.timeoutMs ?? 10000
+  }
+
+  private withTimeout<T>(p: Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('timeout')), this.timeoutMs)
+      p.then((v) => {
+        clearTimeout(timer)
+        resolve(v)
+      }).catch((err) => {
+        clearTimeout(timer)
+        reject(err)
+      })
+    })
+  }
+
+  async anchorPreview(
+    previewId: string,
+    proofCid: string,
+    verdictCid: string,
+    traceId: string,
+  ): Promise<{ txHash: string | null }> {
+    try {
+      const tx = await this.withTimeout(
+        this.contract.anchorPreview(previewId, proofCid, verdictCid, traceId),
+      )
+      const receipt = (await this.withTimeout(tx.wait())) as TransactionReceipt
+      return { txHash: receipt.hash }
+    } catch {
+      return { txHash: null }
+    }
+  }
+
+  async anchorFill(
+    orderId: string,
+    fillCid: string,
+    deltaNotional: bigint,
+    slippageBps: bigint,
+    traceId: string,
+  ): Promise<{ txHash: string | null }> {
+    try {
+      const tx = await this.withTimeout(
+        this.contract.anchorFill(orderId, fillCid, deltaNotional, slippageBps, traceId),
+      )
+      const receipt = (await this.withTimeout(tx.wait())) as TransactionReceipt
+      return { txHash: receipt.hash }
+    } catch {
+      return { txHash: null }
+    }
+  }
+}

--- a/src/lib/supervisor.ts
+++ b/src/lib/supervisor.ts
@@ -1,0 +1,26 @@
+/**
+ * Determine whether an order reduces the absolute position size.
+ */
+export function isReduction(currentQty: number, side: 'buy' | 'sell', qty: number): boolean {
+  const nextQty = currentQty + (side === 'buy' ? +qty : -qty)
+  return Math.abs(nextQty) < Math.abs(currentQty)
+}
+
+export interface SupervisorDecisionCtx {
+  checks: { aceOk: boolean; varOk: boolean; degraded: boolean }
+  order: { side: 'buy' | 'sell'; qty: number }
+  currentQty: number
+}
+
+/**
+ * Combine upstream checks and safe-mode status to decide on an order.
+ */
+export function supervisorDecision(ctx: SupervisorDecisionCtx): 'APPROVE' | 'REJECT' | 'APPROVE_REDUCTION_ONLY' {
+  const { aceOk, varOk, degraded } = ctx.checks
+  const { order, currentQty } = ctx
+  if (!degraded) {
+    return aceOk && varOk ? 'APPROVE' : 'REJECT'
+  }
+  // In degraded mode, only allow reductions
+  return isReduction(currentQty, order.side, order.qty) ? 'APPROVE_REDUCTION_ONLY' : 'REJECT'
+}

--- a/src/lib/var.ts
+++ b/src/lib/var.ts
@@ -1,0 +1,44 @@
+import type { OrderPreviewAction, OrderPreviewProof } from '../types/api'
+
+export interface VarProofClientConfig {
+  baseUrl: string
+  timeoutMs?: number
+}
+
+/**
+ * Client for the zk-VaR proof service with fail-closed semantics.
+ */
+export class VarProofClient {
+  private baseUrl: string
+  private timeoutMs: number
+
+  constructor(cfg: VarProofClientConfig) {
+    this.baseUrl = cfg.baseUrl
+    this.timeoutMs = cfg.timeoutMs ?? 8000
+  }
+
+  async prove(
+    action: OrderPreviewAction,
+  ): Promise<{ proof: OrderPreviewProof | null; degraded: boolean }> {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs)
+    try {
+      const res = await fetch(`${this.baseUrl}/prove`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(action),
+        signal: controller.signal,
+      })
+      if (!res.ok) {
+        return { proof: null, degraded: true }
+      }
+      const proof = (await res.json()) as OrderPreviewProof
+      return { proof, degraded: false }
+    } catch {
+      return { proof: null, degraded: true }
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+}
+

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,26 @@
+export interface OrderPreviewAction {
+  symbol: string
+  side: 'buy' | 'sell'
+  qty: number
+}
+
+export interface OrderPreviewProof {
+  proof_id: string
+  hash: string
+  ok: boolean
+  var_value: number
+}
+
+export interface OrderPreviewPolicy {
+  verdict_id: string
+  allow: boolean
+  reasons?: string[]
+}
+
+export interface OrderPreviewResult {
+  order_preview_id: string
+  action: OrderPreviewAction
+  proof: OrderPreviewProof
+  policy: OrderPreviewPolicy
+  trace_id: string
+}

--- a/src/workers/anchor.ts
+++ b/src/workers/anchor.ts
@@ -1,0 +1,67 @@
+import { AnchorClient } from '../lib/anchor.js'
+
+export interface AnchorWorkerOptions {
+  rpcUrl: string
+  contractAddress: string
+  privateKey: string
+  timeoutMs?: number
+}
+
+/**
+ * AnchorWorker wraps AnchorClient with start/stop hooks.
+ * Actual event consumption will be wired later once messaging exists.
+ */
+export class AnchorWorker {
+  private client: AnchorClient
+  private running = false
+
+  constructor(opts: AnchorWorkerOptions) {
+    this.client = new AnchorClient(opts)
+  }
+
+  start() {
+    this.running = true
+  }
+
+  stop() {
+    this.running = false
+  }
+
+  async anchorPreview(
+    previewId: string,
+    proofCid: string,
+    verdictCid: string,
+    traceId: string,
+  ) {
+    return this.running
+      ? this.client.anchorPreview(previewId, proofCid, verdictCid, traceId)
+      : { txHash: null }
+  }
+
+  async anchorFill(
+    orderId: string,
+    fillCid: string,
+    deltaNotional: bigint,
+    slippageBps: bigint,
+    traceId: string,
+  ) {
+    return this.running
+      ? this.client.anchorFill(orderId, fillCid, deltaNotional, slippageBps, traceId)
+      : { txHash: null }
+  }
+}
+
+export function createAnchorWorkerFromEnv(): AnchorWorker {
+  const rpcUrl = process.env.ANCHOR_RPC_URL
+  const contractAddress = process.env.ANCHOR_CONTRACT_ADDRESS
+  const privateKey = process.env.ANCHOR_PRIVATE_KEY
+  const timeoutMs = process.env.ANCHOR_TIMEOUT_MS
+    ? parseInt(process.env.ANCHOR_TIMEOUT_MS, 10)
+    : undefined
+
+  if (!rpcUrl || !contractAddress || !privateKey) {
+    throw new Error('missing anchoring env vars')
+  }
+
+  return new AnchorWorker({ rpcUrl, contractAddress, privateKey, timeoutMs })
+}

--- a/tests/anchor-worker.test.js
+++ b/tests/anchor-worker.test.js
@@ -1,0 +1,30 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createAnchorWorkerFromEnv } from '../dist/src/workers/anchor.js'
+
+function withEnv(env, fn) {
+  const old = { ...process.env }
+  Object.assign(process.env, env)
+  try {
+    return fn()
+  } finally {
+    process.env = old
+  }
+}
+
+test('creates worker from env vars', () => {
+  withEnv(
+    {
+      ANCHOR_RPC_URL: 'http://localhost:8545',
+      ANCHOR_CONTRACT_ADDRESS: '0x0000000000000000000000000000000000000000',
+      ANCHOR_PRIVATE_KEY:
+        '0x1111111111111111111111111111111111111111111111111111111111111111',
+    },
+    () => {
+      const worker = createAnchorWorkerFromEnv()
+      worker.start()
+      worker.stop()
+      assert.ok(worker)
+    },
+  )
+})

--- a/tests/orders-preview.test.js
+++ b/tests/orders-preview.test.js
@@ -1,0 +1,30 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { HttpException } from '@nestjs/common';
+import { OrdersService } from '../dist/server/src/orders.service.js';
+
+const okPolicy = { verdict_id: 'v1', allow: true, reasons: [] };
+const okProof = { proof_id: 'p1', hash: '0x', ok: true, var_value: 0 };
+
+test('returns preview when checks pass', async () => {
+  const svc = new OrdersService({
+    ace: { evaluate: async () => ({ policy: okPolicy, degraded: false }) },
+    var: { prove: async () => ({ proof: okProof, degraded: false }) },
+  });
+  const res = await svc.preview({ symbol: 'AAPL', side: 'buy', qty: 1 }, 0);
+  assert.equal(res.action.symbol, 'AAPL');
+  assert.equal(res.policy.verdict_id, 'v1');
+  assert.equal(res.proof.proof_id, 'p1');
+});
+
+test('throws in safe mode when services degraded', async () => {
+  const svc = new OrdersService({
+    ace: { evaluate: async () => ({ policy: null, degraded: true }) },
+    var: { prove: async () => ({ proof: null, degraded: true }) },
+  });
+  await assert.rejects(
+    () => svc.preview({ symbol: 'AAPL', side: 'buy', qty: 1 }, 0),
+    (err) => err instanceof HttpException && err.getStatus() === 409,
+  );
+});
+

--- a/tests/supervisor.test.js
+++ b/tests/supervisor.test.js
@@ -1,0 +1,21 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { supervisorDecision } from '../dist/src/lib/supervisor.js'
+
+test('approves when checks pass', () => {
+  const decision = supervisorDecision({
+    checks: { aceOk: true, varOk: true, degraded: false },
+    order: { side: 'buy', qty: 1 },
+    currentQty: 0,
+  })
+  assert.equal(decision, 'APPROVE')
+})
+
+test('allows only reductions when degraded', () => {
+  const decision = supervisorDecision({
+    checks: { aceOk: false, varOk: false, degraded: true },
+    order: { side: 'sell', qty: 5 },
+    currentQty: 10,
+  })
+  assert.equal(decision, 'APPROVE_REDUCTION_ONLY')
+})


### PR DESCRIPTION
## Summary
- implement OrdersService that consults ACE and zk-VaR in parallel and applies supervisor safe-mode
- wire OrdersService and PrismaService into NestJS gateway and document preview endpoint in README and OpenAPI spec
- add unit tests for preview orchestration and update existing tests for new build output structure

## Testing
- `npx eslint src/lib/ace.ts src/lib/var.ts src/lib/supervisor.ts src/lib/anchor.ts src/types/api.ts src/workers/anchor.ts server/src/app.module.ts server/src/orders.controller.ts server/src/orders.service.ts server/src/prisma.service.ts`
- `npm test`
- `npm audit` *(fails: 403 Forbidden - POST https://registry.npmjs.org/-/npm/v1/security/advisories/bulk)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a92b583c8326811979582e44dbcb